### PR TITLE
Updated a grammar error on the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Version in use of selenium has a bug, patch needed to work.
 npm run start
 ```
 
-Enter password and password, wait for firefox to open, resolve Captcha or authenticate via facebook through firefox.
+Enter your skillshare email and password, wait for firefox to open, resolve Captcha or authenticate via facebook through firefox.
 
 Choose the classes by the console or insert a specific id found in the video URL.
 


### PR DESCRIPTION
On line 57, there was an error saying password and password instead of email and password